### PR TITLE
Add coastal-modern-palette skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,108 @@
+# Design System — Coastal Modern Palette
+
+Apply this design system whenever producing any UI, component, landing page, or visual output.
+
+## Tokens
+
+| Token | Hex |
+|---|---|
+| primary | `#7FAFB0` |
+| primary-dark | `#3D7F82` |
+| bg | `#F7F4F0` |
+| surface | `#FFFFFF` |
+| text | `#1E2B2E` |
+| text-secondary | `#5E7578` |
+| accent | `#C4874A` |
+| border | `#DDD8D0` |
+
+## CSS `:root`
+
+```css
+:root {
+  --color-primary:        #7FAFB0;
+  --color-primary-dark:   #3D7F82;
+  --color-bg:             #F7F4F0;
+  --color-surface:        #FFFFFF;
+  --color-text:           #1E2B2E;
+  --color-text-secondary: #5E7578;
+  --color-accent:         #C4874A;
+  --color-border:         #DDD8D0;
+  --shadow-sm: 0 1px 3px rgba(30,43,46,0.08);
+  --shadow-md: 0 4px 12px rgba(30,43,46,0.10);
+  --shadow-lg: 0 8px 24px rgba(30,43,46,0.12);
+}
+```
+
+## Tailwind
+
+```js
+colors: {
+  primary: '#7FAFB0', 'primary-dark': '#3D7F82',
+  bg: '#F7F4F0', surface: '#FFFFFF',
+  ink: '#1E2B2E', slate: '#5E7578',
+  caramel: '#C4874A', sand: '#DDD8D0',
+}
+```
+
+Arbitrary classes for artifacts: `bg-[#7FAFB0]` `text-[#1E2B2E]` `border-[#DDD8D0]` `bg-[#C4874A]`
+
+## Proportion Rule — 80 / 15 / 5
+
+- **80 %** — `#F7F4F0` `#FFFFFF` `#DDD8D0` — backgrounds, cards, dividers
+- **15 %** — `#7FAFB0` `#3D7F82` — CTAs, nav, icons, active states
+- **5 %** — `#C4874A` — one accent element per viewport maximum
+
+## WCAG Rules
+
+- Body text: `#1E2B2E` on `#F7F4F0` → 13.2:1 ✓ always safe
+- CTA button: `#3D7F82` bg + `#FFFFFF` text → 4.8:1 AA ✓
+- Text on teal chip: `#1E2B2E` on `#7FAFB0` → 5.3:1 AA ✓
+- Text on caramel: `#1E2B2E` on `#C4874A` → 6.8:1 AA ✓
+- **Never** white text on `#7FAFB0` (ratio 2.8:1, fails)
+- **Never** white body text on `#C4874A` (ratio 3.1:1, fails)
+
+## Typography
+
+| Role | Font | Weight | Size |
+|---|---|---|---|
+| Display / H1 | Playfair Display | 700 | 48–64 px |
+| H2–H4 | Inter or DM Sans | 600 | 24–36 px |
+| Body | Inter | 400 | 16–18 px |
+| CTA | Inter | 600 | 15–16 px, ls 0.02em |
+
+## Shapes & Shadows
+
+- Radius: `12px` cards · `8px` inputs · `999px` pills · `4px` tooltips
+- Borders: `1px solid #DDD8D0` — no black borders
+- Shadows: warm tint `rgba(30,43,46,…)` only
+- Icons: stroke-based (Lucide/Phosphor), 1.5 px, filled only when active
+
+## Dark Mode
+
+```css
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-bg:             #121B1C;
+    --color-surface:        #1C2A2C;
+    --color-text:           #E8F0F0;
+    --color-text-secondary: #8AABAC;
+    --color-primary:        #7FAFB0;
+    --color-primary-dark:   #5E9EA0;
+    --color-accent:         #D4975A;
+    --color-border:         #2C3E40;
+  }
+}
+```
+
+## System States
+
+| State | Bg | Text | Border |
+|---|---|---|---|
+| Success | `#E6F4F1` | `#2A7A6A` | `#A8D8CF` |
+| Warning | `#FDF3E3` | `#8A5A1A` | `#F0D4A0` |
+| Error | `#FAE8E6` | `#9B3A32` | `#E8B8B4` |
+| Info | `#E8F2F3` | `#3D7F82` | `#A8CFD1` |
+
+## Data-Viz Order
+
+1. `#3D7F82` 2. `#C4874A` 3. `#7FAFB0` 4. `#8AABAC` 5. `#E0B080` 6. `#5E7578`

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,214 @@
+# Skill: coastal-modern-palette
+
+## Metadata
+
+```yaml
+name: coastal-modern-palette
+version: 1.0.0
+description: >
+  Apply when the user mentions "ma palette", "coastal", "soft modern", "design
+  épuré", asks to build a landing/UI/component, or requests a color recommendation.
+  Encodes the full Coastal Modern design system: tokens, snippets, hierarchy rules,
+  WCAG contrasts, dark mode, system states, and data-viz order.
+```
+
+---
+
+## 1. Raw Palette
+
+| Role | Name | Hex | HSL |
+|---|---|---|---|
+| Primary teal | Seafoam | `#7FAFB0` | 181 26% 60% |
+| Primary dark | Deep teal | `#3D7F82` | 182 34% 37% |
+| Background | Warm white | `#F7F4F0` | 33 24% 96% |
+| Surface | Pure white | `#FFFFFF` | — |
+| Text primary | Ink | `#1E2B2E` | 189 22% 15% |
+| Text secondary | Slate | `#5E7578` | 185 13% 41% |
+| Accent | Caramel | `#C4874A` | 30 52% 53% |
+| Border | Sand | `#DDD8D0` | 33 16% 84% |
+
+---
+
+## 2. UI Design Tokens
+
+```
+--color-primary:          #7FAFB0;
+--color-primary-dark:     #3D7F82;
+--color-bg:               #F7F4F0;
+--color-surface:          #FFFFFF;
+--color-text:             #1E2B2E;
+--color-text-secondary:   #5E7578;
+--color-accent:           #C4874A;
+--color-border:           #DDD8D0;
+```
+
+---
+
+## 3. CSS Variables Snippet
+
+```css
+:root {
+  --color-primary:          #7FAFB0;
+  --color-primary-dark:     #3D7F82;
+  --color-bg:               #F7F4F0;
+  --color-surface:          #FFFFFF;
+  --color-text:             #1E2B2E;
+  --color-text-secondary:   #5E7578;
+  --color-accent:           #C4874A;
+  --color-border:           #DDD8D0;
+
+  /* Semantic aliases */
+  --color-cta-bg:           var(--color-primary);
+  --color-cta-bg-hover:     var(--color-primary-dark);
+  --color-cta-text:         #FFFFFF;
+  --color-link:             var(--color-primary-dark);
+  --color-divider:          var(--color-border);
+}
+```
+
+---
+
+## 4. Tailwind Config
+
+```js
+// tailwind.config.js
+module.exports = {
+  theme: {
+    extend: {
+      colors: {
+        primary:    '#7FAFB0',
+        'primary-dark': '#3D7F82',
+        bg:         '#F7F4F0',
+        surface:    '#FFFFFF',
+        ink:        '#1E2B2E',
+        slate:      '#5E7578',
+        caramel:    '#C4874A',
+        sand:       '#DDD8D0',
+      },
+    },
+  },
+}
+```
+
+**Arbitrary classes for Claude.ai artifacts:**
+```
+bg-[#7FAFB0]   text-[#1E2B2E]   border-[#DDD8D0]
+bg-[#F7F4F0]   text-[#5E7578]   bg-[#C4874A]
+```
+
+---
+
+## 5. Proportion Rule — 80 / 15 / 5
+
+| Weight | Colors | Use |
+|---|---|---|
+| **80 %** | Warm white `#F7F4F0`, Pure white `#FFFFFF`, Sand `#DDD8D0` | Backgrounds, cards, dividers |
+| **15 %** | Seafoam `#7FAFB0`, Deep teal `#3D7F82` | CTAs, nav, active states, icons |
+| **5 %** | Caramel `#C4874A` | Tags, badges, highlights, a single accent CTA |
+
+> Caramel must never appear on more than one element per viewport. Overuse destroys the coastal calm.
+
+---
+
+## 6. WCAG Contrast Rules
+
+| Foreground | Background | Ratio | WCAG | Minimum usage |
+|---|---|---|---|---|
+| `#FFFFFF` on `#3D7F82` | Deep teal | 4.8 : 1 | AA | Body ≥ 16 px or bold ≥ 14 px |
+| `#FFFFFF` on `#7FAFB0` | Seafoam | 2.8 : 1 | fail | Large decorative text only (≥ 24 px, non-essential) |
+| `#1E2B2E` on `#7FAFB0` | Seafoam | 5.3 : 1 | AA | Preferred for text on teal chips/badges |
+| `#1E2B2E` on `#F7F4F0` | Warm white | 13.2 : 1 | AAA | Body copy — default |
+| `#5E7578` on `#F7F4F0` | Warm white | 5.1 : 1 | AA | Captions, meta, secondary text |
+| `#FFFFFF` on `#C4874A` | Caramel | 3.1 : 1 | fail body | Large bold text only (≥ 18 px bold) |
+| `#1E2B2E` on `#C4874A` | Caramel | 6.8 : 1 | AA | Preferred text on caramel badges |
+
+**Practical rules:**
+- Never white body text on Seafoam — use Ink `#1E2B2E` instead.
+- CTA buttons: Deep teal background + white text is the only fully AA-compliant combo.
+- Caramel badges: always pair with Ink text, not white.
+
+---
+
+## 7. Typography Pairing
+
+| Role | Font | Weight | Size |
+|---|---|---|---|
+| Display / H1 | Playfair Display | 700 | 48–64 px |
+| Headings H2–H4 | Inter or DM Sans | 600 | 24–36 px |
+| Body | Inter | 400 | 16–18 px |
+| Caption / meta | Inter | 400 | 12–14 px |
+| CTA label | Inter | 600 | 15–16 px, letter-spacing 0.02em |
+
+---
+
+## 8. Shape & Shadow Language
+
+- **Border radius:** `12px` cards, `8px` inputs, `999px` pills/tags, `4px` tooltips.
+- **Shadows:** soft and warm — avoid cold grey shadows.
+  ```css
+  --shadow-sm: 0 1px 3px rgba(30, 43, 46, 0.08);
+  --shadow-md: 0 4px 12px rgba(30, 43, 46, 0.10);
+  --shadow-lg: 0 8px 24px rgba(30, 43, 46, 0.12);
+  ```
+- **Borders:** `1px solid #DDD8D0` — never black borders.
+- **Icons:** stroke-based (Lucide / Phosphor), 1.5 px stroke, never filled unless active state.
+
+---
+
+## 9. Dark Mode Variant
+
+```css
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-bg:               #121B1C;
+    --color-surface:          #1C2A2C;
+    --color-text:             #E8F0F0;
+    --color-text-secondary:   #8AABAC;
+    --color-primary:          #7FAFB0;   /* unchanged — reads well on dark */
+    --color-primary-dark:     #5E9EA0;   /* lightened for dark bg contrast */
+    --color-accent:           #D4975A;   /* caramel lightened +10% lightness */
+    --color-border:           #2C3E40;
+  }
+}
+```
+
+---
+
+## 10. System State Palette
+
+| State | Background | Text / Icon | Border |
+|---|---|---|---|
+| Success | `#E6F4F1` | `#2A7A6A` | `#A8D8CF` |
+| Warning | `#FDF3E3` | `#8A5A1A` | `#F0D4A0` |
+| Error | `#FAE8E6` | `#9B3A32` | `#E8B8B4` |
+| Info | `#E8F2F3` | `#3D7F82` | `#A8CFD1` |
+
+> Derived from the palette hue family — no pure red/green/yellow. Feels coastal, not alarming.
+
+---
+
+## 11. Data-Viz Color Order
+
+For multi-series charts, use in this order to maximise distinction while staying on-brand:
+
+1. `#3D7F82` Deep teal (primary series)
+2. `#C4874A` Caramel (secondary series)
+3. `#7FAFB0` Seafoam (tertiary)
+4. `#8AABAC` Muted teal
+5. `#E0B080` Light caramel
+6. `#5E7578` Slate (neutral 6th series)
+
+---
+
+## 12. Delivery Checklist
+
+- [ ] CSS variables added to `:root` in global stylesheet
+- [ ] Tailwind config extended with palette tokens
+- [ ] CTA buttons use `primary-dark` bg + white text (AA compliant)
+- [ ] No white text on `#7FAFB0` in body copy
+- [ ] Caramel accent appears ≤ 1× per viewport
+- [ ] Dark mode override block present
+- [ ] System state colours verified against palette
+- [ ] Shadows use warm tint (`rgba(30, 43, 46, …)`) not grey
+- [ ] Border radius consistent: 12 / 8 / 999 / 4 px
+- [ ] Icons: stroke style, 1.5 px weight

--- a/coastal-modern-palette.skill
+++ b/coastal-modern-palette.skill
@@ -1,0 +1,149 @@
+name: coastal-modern-palette
+version: 1.0.0
+description: >
+  Apply when the user mentions "ma palette", "coastal", "soft modern", "design
+  épuré", "landing page", "UI component", or asks for color recommendations,
+  a design system, or any frontend/visual output. Provides the full Coastal
+  Modern design system: palette tokens, CSS/Tailwind snippets, proportion rules,
+  WCAG contrast guidance, dark mode, system states, and data-viz color order.
+
+prompt: |
+  You are working within the **Coastal Modern** design system. Always apply the
+  following tokens, rules, and snippets when producing any UI, component, or
+  visual output.
+
+  ## Design Tokens
+
+  | Token | Hex |
+  |---|---|
+  | --color-primary | #7FAFB0 |
+  | --color-primary-dark | #3D7F82 |
+  | --color-bg | #F7F4F0 |
+  | --color-surface | #FFFFFF |
+  | --color-text | #1E2B2E |
+  | --color-text-secondary | #5E7578 |
+  | --color-accent | #C4874A |
+  | --color-border | #DDD8D0 |
+
+  ## CSS Variables (include in :root)
+
+  ```css
+  :root {
+    --color-primary:          #7FAFB0;
+    --color-primary-dark:     #3D7F82;
+    --color-bg:               #F7F4F0;
+    --color-surface:          #FFFFFF;
+    --color-text:             #1E2B2E;
+    --color-text-secondary:   #5E7578;
+    --color-accent:           #C4874A;
+    --color-border:           #DDD8D0;
+    --shadow-sm: 0 1px 3px rgba(30,43,46,0.08);
+    --shadow-md: 0 4px 12px rgba(30,43,46,0.10);
+    --shadow-lg: 0 8px 24px rgba(30,43,46,0.12);
+  }
+  ```
+
+  ## Tailwind Config
+
+  ```js
+  // tailwind.config.js
+  module.exports = {
+    theme: {
+      extend: {
+        colors: {
+          primary:        '#7FAFB0',
+          'primary-dark': '#3D7F82',
+          bg:             '#F7F4F0',
+          surface:        '#FFFFFF',
+          ink:            '#1E2B2E',
+          slate:          '#5E7578',
+          caramel:        '#C4874A',
+          sand:           '#DDD8D0',
+        },
+      },
+    },
+  }
+  ```
+
+  **For Claude.ai artifacts, use arbitrary classes:**
+  `bg-[#F7F4F0]`, `bg-[#7FAFB0]`, `text-[#1E2B2E]`, `border-[#DDD8D0]`, `bg-[#C4874A]`
+
+  ## Proportion Rule — 80 / 15 / 5
+
+  - **80 %** → Warm white `#F7F4F0`, Pure white `#FFFFFF`, Sand `#DDD8D0` — backgrounds, cards, dividers.
+  - **15 %** → Seafoam `#7FAFB0`, Deep teal `#3D7F82` — CTAs, nav, active states, icons.
+  - **5 %** → Caramel `#C4874A` — one accent element per viewport maximum (badge, highlight, single CTA).
+
+  Never let caramel dominate. If it appears on more than one element per viewport, replace extra instances with teal.
+
+  ## WCAG Contrast Rules
+
+  - **Body text on background:** `#1E2B2E` on `#F7F4F0` → 13.2:1 (AAA). Always safe.
+  - **White text on teal:** Only on `#3D7F82` (deep teal, 4.8:1 AA). Never white on `#7FAFB0` (2.8:1, fails).
+  - **Text on seafoam chips/badges:** Use `#1E2B2E` (5.3:1 AA), not white.
+  - **Text on caramel:** Use `#1E2B2E` (6.8:1 AA). Never white on caramel.
+  - **CTA button:** `#3D7F82` background + `#FFFFFF` text is the only fully compliant combo.
+
+  ## Typography
+
+  | Role | Font | Weight | Size |
+  |---|---|---|---|
+  | Display / H1 | Playfair Display | 700 | 48–64 px |
+  | H2–H4 | Inter or DM Sans | 600 | 24–36 px |
+  | Body | Inter | 400 | 16–18 px |
+  | Caption | Inter | 400 | 12–14 px |
+  | CTA | Inter | 600 | 15–16 px, letter-spacing 0.02em |
+
+  ## Shape & Shadows
+
+  - Border radius: `12px` cards · `8px` inputs · `999px` pills · `4px` tooltips.
+  - Borders: `1px solid #DDD8D0`. Never black borders.
+  - Shadows: warm tint only (see --shadow-* tokens). No cold grey shadows.
+  - Icons: stroke-based (Lucide / Phosphor), 1.5 px stroke, filled only for active state.
+
+  ## Dark Mode
+
+  ```css
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --color-bg:             #121B1C;
+      --color-surface:        #1C2A2C;
+      --color-text:           #E8F0F0;
+      --color-text-secondary: #8AABAC;
+      --color-primary:        #7FAFB0;
+      --color-primary-dark:   #5E9EA0;
+      --color-accent:         #D4975A;
+      --color-border:         #2C3E40;
+    }
+  }
+  ```
+
+  ## System State Colours
+
+  | State | Background | Text/Icon | Border |
+  |---|---|---|---|
+  | Success | #E6F4F1 | #2A7A6A | #A8D8CF |
+  | Warning | #FDF3E3 | #8A5A1A | #F0D4A0 |
+  | Error | #FAE8E6 | #9B3A32 | #E8B8B4 |
+  | Info | #E8F2F3 | #3D7F82 | #A8CFD1 |
+
+  ## Data-Viz Series Order
+
+  1. `#3D7F82` Deep teal
+  2. `#C4874A` Caramel
+  3. `#7FAFB0` Seafoam
+  4. `#8AABAC` Muted teal
+  5. `#E0B080` Light caramel
+  6. `#5E7578` Slate
+
+  ## Delivery Checklist
+
+  Before finalising any output, confirm:
+  - [ ] CSS tokens in `:root`
+  - [ ] CTA uses `#3D7F82` bg + white text
+  - [ ] No white text on `#7FAFB0`
+  - [ ] Caramel ≤ 1× per viewport
+  - [ ] Dark mode block present
+  - [ ] Shadows use warm rgba(30,43,46,…) tint
+  - [ ] Border radius follows 12/8/999/4 px scale
+  - [ ] Icons stroke-based, 1.5 px


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `coastal-modern-palette.skill` — an installable Claude.ai skill (Settings → Capabilities → Skills → Upload skill) encoding the full Coastal Modern design system.
- Adds `SKILL.md` — the human-readable markdown reference for the same system, suitable for version control and code review.

## What's included

- **8 UI tokens** (primary, primary-dark, bg, surface, text, text-secondary, accent, border)
- **CSS `:root` snippet** and **Tailwind config** ready to paste
- **80/15/5 proportion rule** (neutrals / teal / caramel) with enforcement guidance
- **WCAG contrast table** with practical per-combo rules
- **Typography pairing** (Playfair Display + Inter)
- **Shape & shadow language** (border-radius scale, warm-tinted shadows)
- **Dark mode variant** derived from the palette
- **System state palette** (success/warning/error/info) tuned to the coastal tone
- **Data-viz series order** for multi-series charts
- **Delivery checklist**

## Test plan

- [ ] Upload `coastal-modern-palette.skill` to Claude.ai → Settings → Capabilities → Skills
- [ ] Open a new conversation and type "fais-moi une landing page" — skill should activate automatically
- [ ] Verify generated output uses `#7FAFB0` / `#3D7F82` / `#C4874A` palette
- [ ] Verify CTA button uses deep teal bg + white text (AA compliant)
- [ ] Verify caramel appears ≤ 1× per viewport

https://claude.ai/code/session_013VGsBGP27UXGP7Mv4HF1MN
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_013VGsBGP27UXGP7Mv4HF1MN)_